### PR TITLE
Update requirements.txt of generated package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+*.egg-info
+*.mo
+.*project
+*.py[cod]
+.settings
+# dirs
+bin/
+tmp/
+build/
+lib/
+.tox/
+develop-eggs/
+include/
+local/
+_build
+__pycache__
+.cache
+.vagrant
+# files
+pip-selfcheck.json
+.python-version
+.Python
+.coverage*
+coverage.xml
+Vagrantfile
+.DS_Store
+/pyvenv.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.4 (unreleased)
+----------------
+
+- Use https://dist.plone.org/release/5.2-latest/requirements.txt in
+  requirements.txt of generated package.
+  [wesleybl]
+
+
 0.3 (2019-08-16)
 ----------------
 

--- a/bobtemplates/migration/jsonify/constraints.txt
+++ b/bobtemplates/migration/jsonify/constraints.txt
@@ -1,0 +1,1 @@
+-c constraints_plone52.txt

--- a/bobtemplates/migration/jsonify/constraints_plone51.txt
+++ b/bobtemplates/migration/jsonify/constraints_plone51.txt
@@ -1,0 +1,4 @@
+-c https://dist.plone.org/release/5.1-latest/requirements.txt
+# setuptools==42.0.2
+# zc.buildout==2.13.3
+# wheel

--- a/bobtemplates/migration/jsonify/constraints_plone52.txt
+++ b/bobtemplates/migration/jsonify/constraints_plone52.txt
@@ -1,0 +1,4 @@
+-c https://dist.plone.org/release/5.2-latest/requirements.txt
+# setuptools==42.0.2
+# zc.buildout==2.13.3
+# wheel

--- a/bobtemplates/migration/jsonify/requirements.txt
+++ b/bobtemplates/migration/jsonify/requirements.txt
@@ -1,2 +1,3 @@
-setuptools==38.2.4
-zc.buildout==2.11.4
+-c constraints.txt
+setuptools
+zc.buildout


### PR DESCRIPTION
Use https://dist.plone.org/release/5.2-latest/requirements.txt in requirements.txt of generated package.

Current versions of `setuptools/zc.buildout` make the buildout in an infinite loop.